### PR TITLE
fix: typo in `lua/lush_theme/arctic.lua`

### DIFF
--- a/lua/lush_theme/arctic.lua
+++ b/lua/lush_theme/arctic.lua
@@ -221,7 +221,7 @@ local theme = lush(function(injected_functions)
     LspReferenceRead { SelectionHighlightBackground },
     LspReferenceWrite { SelectionHighlightBackground },
     LspCodeLens { CodeLens },
-    -- LspCodeLensSeparator { }, -- Used to color the seperator between two or more code lens.
+    -- LspCodeLensSeparator { }, -- Used to color the separator between two or more code lens.
     LspSignatureActiveParameter { MatchedCharacters },
     LspInlayHint { InlayHint },
 


### PR DESCRIPTION
Just happened to see this while customizing :slightly_smiling_face: 