### PR TITLE
Match color of Arctic operator to Dark+ operator

### DIFF
--- a/lua/lush_theme/arctic.lua
+++ b/lua/lush_theme/arctic.lua
@@ -320,7 +320,7 @@ local theme = lush(function(injected_functions)
     sym("@keyword") { Keyword }, -- keywords not fitting into specific categories
     sym("@keyword.coroutine") { fg = dark_pink }, -- keywords related to coroutines (e.g. `go` in Go, `async/await` in Python)
     sym("@keyword.function") { fg = dark_blue }, -- keywords that define a function (e.g. `func` in Go, `def` in Python)
-    sym("@keyword.operator") { sym("@operator") }, -- operators that are English words (e.g. `and` / `or`)
+    sym("@keyword.operator") { fg = dark_blue }, -- operators that are English words (e.g. `and` / `or`)
     sym("@keyword.import") { Include }, -- keywords for including modules (e.g. `import` / `from` in Python)
     sym("@keyword.type") { fg = dark_blue }, -- keywords describing composite types (e.g. `struct`, `enum`)
     sym("@keyword.modifier") { fg = dark_blue }, -- keywords modifying other constructs (e.g. `const`, `static`, `public`)


### PR DESCRIPTION
I noticed that the operators `and`, `or`, and `new` in JavaScript, Python, and other languages did not match the color scheme originally used in **Dark+**. Therefore, I've updated the highlighting of these operators to more closely align with VSCode.

| Dark+ | Arctic Before | Arctic After |
|:-:|:-:|:-:|
|<img src="https://github.com/rockyzhang24/arctic.nvim/assets/70251272/216ae6e4-b37d-469a-ac1b-0a7e75a08b1b" width="100%">| <img src="https://github.com/rockyzhang24/arctic.nvim/assets/70251272/04c77452-5de1-4f60-ae20-7574549ac86f" width="100%"> | <img src="https://github.com/rockyzhang24/arctic.nvim/assets/70251272/ff3bc400-0fd7-4399-a284-70adc887456d" width="100%"> |